### PR TITLE
Use same definition of private as Stripe's smokescreen

### DIFF
--- a/iptool.go
+++ b/iptool.go
@@ -95,11 +95,12 @@ func New() (iptool Tool, includesLocalInterfaces bool) {
 }
 
 func (t *tool) IsPrivate(addr *net.IPAddr) bool {
-	for _, privateNet := range t.privateNets {
-		if privateNet.Contains(addr.IP) {
-			log.Debugf("%v contains %v", privateNet, addr.IP)
-			return true
-		}
-	}
-	return false
+	return !addr.IP.IsGlobalUnicast() || addr.IP.IsLoopback()
+	// for _, privateNet := range t.privateNets {
+	// 	if privateNet.Contains(addr.IP) {
+	// 		log.Debugf("%v contains %v", privateNet, addr.IP)
+	// 		return true
+	// 	}
+	// }
+	// return false
 }

--- a/landetect/main.go
+++ b/landetect/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/getlantern/golog"
-	"github.com/getlantern/iptool"
 	"net"
 	"os"
+
+	"github.com/getlantern/golog"
+	"github.com/getlantern/iptool"
 )
 
 var (
@@ -16,9 +17,9 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("Please specify at least one ip address to check")
 	}
-	tool, err := iptool.New()
-	if err != nil {
-		log.Fatal(err)
+	tool, ok := iptool.New()
+	if !ok {
+		log.Fatal("Unable to build iptool")
 	}
 
 	for _, addr := range os.Args[1:] {


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/5877

Note - the unit test is broken, we need to see if we care about any of the failures (I think we do).

I think the two main categories of failure are:

1. Non-loopback network interfaces like `en0` on my machine
2. Certain special-use IPv6 addresses from rfc5156